### PR TITLE
Change for ./configure args

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,26 +7,27 @@ source $HOME/.cargo/env
 
 if [ -v WITH_LATEST_MMTK_CORE ]
 then
-  git clone https://github.com/mmtk/mmtk-core
-  pushd mmtk-core
+  git clone --depth=1 https://github.com/mmtk/mmtk-core
 else
-  git clone https://github.com/mmtk/mmtk-core # https://github.com/wks/mmtk-core
-  pushd mmtk-core
+  git clone --depth=1 https://github.com/mmtk/mmtk-core # https://github.com/wks/mmtk-core
   # Currently no difference
 fi
+
+# Building mmtk-core in the mmtk-core directory has no effect for mmtk-ruby.
+# When building mmtk-ruby, it will build the source of mmtk-core, too,
+# and the generated object files will be in mmtk-ruby/mmtk/target/
+
 export RUSTUP_TOOLCHAIN=nightly # $(cat rust-toolchain)
 rustup toolchain install $RUSTUP_TOOLCHAIN
-cargo +nightly build
-popd
 
-git clone https://github.com/mmtk/mmtk-ruby
+git clone --depth=1 https://github.com/mmtk/mmtk-ruby
 pushd mmtk-ruby/mmtk
 sed -i 's/^mmtk =/#mmtk =/g' Cargo.toml
 cat ../../Cargo.toml.part >> Cargo.toml
-cargo build
+cargo +nightly build --release
 popd
 
-git clone https://github.com/mmtk/ruby
+git clone --depth=1 https://github.com/mmtk/ruby
 pushd ruby
 if [ -v WITH_UPSTREAM_RUBY ]
 then
@@ -36,14 +37,13 @@ then
   git fetch upstream
   git merge upstream/master
 fi
-cp ../mmtk-ruby/mmtk/target/debug/libmmtk_ruby.so ./
 sudo apt-get install -y autoconf bison
 ./autogen.sh
-./configure --with-mmtk-ruby --prefix=$PWD/build --disable-install-doc
-export LD_LIBRARY_PATH=$PWD
+./configure --with-mmtk-ruby=../mmtk-ruby --prefix=$PWD/build --disable-install-doc
 export MMTK_PLAN=MarkSweep
-export THIRD_PARTY_HEAP_LIMIT=10000000
+export THIRD_PARTY_HEAP_LIMIT=500000000
 make miniruby -j
-export RUST_LOG=trace
+export RUST_LOG=info
 ./miniruby -e 'puts "Hello world!"'
+make install -j
 popd


### PR DESCRIPTION
Now the `--with-mmtk-ruby=/path/to/mmtk-ruby` option or `./configure` must point to the mmtk-ruby repository. while previously it was just a yes/no switch.  It now searches for the release build of mmtk-ruby by default.

Now it uses rpath to locate libmmtk-ruby.so, therefore LD_LIBRARY_PATH is no longer necessary, and it is also not necessary to
copy the .so manually.

I tested the script with an LXC image based on `ubuntu:20.04`.  During `make install -j`, I see an error like this:
```
/root/ruby/tool/extlibs.rb:6:in `require': cannot load such file -- digest (LoadError)
        from /root/ruby/tool/extlibs.rb:6:in `<top (required)>'
        from /root/ruby/ext/psych/extconf.rb:24:in `require_relative'
        from /root/ruby/ext/psych/extconf.rb:24:in `<top (required)>'
        from ./ext/extmk.rb:217:in `load'
        from ./ext/extmk.rb:217:in `block in extmake'
        from /root/ruby/lib/mkmf.rb:324:in `open'
        from ./ext/extmk.rb:213:in `extmake'
        from ./ext/extmk.rb:577:in `block in <main>'
        from ./ext/extmk.rb:573:in `each'
        from ./ext/extmk.rb:573:in `<main>'
make[1]: *** [ext/configure-ext.mk:105: ext/psych/exts.mk] Error 1
make[1]: *** Waiting for unfinished jobs....
```

This error exists **even for vanilla ruby from https://github.com/ruby/ruby.git**.  I don't know what I missed, because it builds okay on my Linux host outside LXC.