### PR TITLE
Do nightly releases of builds

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -65,3 +65,20 @@ jobs:
       with:
         name: release-build
         path: '*.tar.gz'
+
+  github-release:
+    name: Create GitHub release
+    needs: [build-debug, build-release]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Download builds
+      uses: actions/download-artifact@v3
+    - name: Display structure of downloaded files
+      run: ls -R
+    - name: Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          debug-build/*.tar.gz
+          release-build/*.tar.gz
+        tag_name: nightly

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 This repository provides builds of the [Ruby](https://www.ruby-lang.org/)
 programming language, with [MMTk](https://www.mmtk.io/) as a garbage collector.
-To download a build, find a recent green build at
-https://github.com/chrisseaton/ruby-mmtk-builder/actions/workflows/builder.yaml
+To download a build, find a recent nightly release at
+https://github.com/chrisseaton/ruby-mmtk-builder/releases/tag/nightly
 and download either the debug or release artefact.
 
 You need to set a *plan* (garbage collection algorithm) and a heap size


### PR DESCRIPTION
Hey 👋 I think I saw a message from you where you said you would like to have nightly releases of the builds. I haven't worked with GitHub actions a lot but thought I'd give it a shot.

I did try the workflow on my fork and it seemed to have worked fine.
Release: https://github.com/Max-Leopold/ruby-mmtk-builder/releases
Workflow run: https://github.com/Max-Leopold/ruby-mmtk-builder/actions/runs/2366412343