### PR TITLE
Remove old release artifacts when creating new nightly release

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -70,15 +70,17 @@ jobs:
     name: Create GitHub release
     needs: [build-debug, build-release]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: Download builds
       uses: actions/download-artifact@v3
-    - name: Display structure of downloaded files
-      run: ls -R
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: ncipollo/release-action@v1
       with:
-        files: |
-          debug-build/*.tar.gz
-          release-build/*.tar.gz
-        tag_name: nightly
+        artifacts: "debug-build/*.tar.gz,release-build/*.tar.gz"
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: nightly
+        removeArtifacts: true
+        commit: main
+        allowUpdates: true


### PR DESCRIPTION
I noticed that unfortunately the workflow I created before does not remove the old artifacts but instead only adds the new artifacts to the old release. I think it's preferably when there are only the most up to date builds present on the release.

The action I used before does not support this though, so I switched it for a comparable action. Both the old and the new action are linked as maintained actions in the official GitHub [actions/create-release](https://github.com/actions/create-release#github-action---releases-api) so I think they are safe to use.

Workflow run: https://github.com/Max-Leopold/ruby-mmtk-builder/actions/runs/2376547925