### PR TITLE
Use stable Rust toolchain instead of nightly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ then
 fi
 popd
 
-export RUSTUP_TOOLCHAIN=nightly # $(cat mmtk-core/rust-toolchain)
+export RUSTUP_TOOLCHAIN=stable # $(cat mmtk-core/rust-toolchain)
 rustup toolchain install $RUSTUP_TOOLCHAIN
 
 git clone https://github.com/mmtk/mmtk-ruby
@@ -25,9 +25,9 @@ sed -i 's/^mmtk =/#mmtk =/g' Cargo.toml
 cat ../../Cargo.toml.part >> Cargo.toml
 if [ -v WITH_DEBUG ]
 then
-  cargo +nightly build
+  cargo build
 else
-  cargo +nightly build --release
+  cargo build --release
 fi
 popd
 


### PR DESCRIPTION
I removed dependencies on nightly features in the mmtk-ruby repository.

The current build.sh script should still work, but we can now use the `stable` toolchain instead of `nightly`.

The toolchain in `mmtk-core/rust-toolchain` is several versions behind the latest stable (currently 1.59 instead of the latest 1.62), but it should work, too.